### PR TITLE
Feature/JPRO-59 Make Concept Window Default Size Same as Drop Zone Ar…

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/journal/journal.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/journal/journal.fxml
@@ -138,7 +138,7 @@
                      <center>
                         <ScrollPane fx:id="desktopSurfaceScrollPane" focusTraversable="true" styleClass="desktop-scroll-pane">
                            <AnchorPane fx:id="desktopSurfacePane" maxHeight="1800.0" maxWidth="2800.0" prefHeight="1800.0" prefWidth="2800.0" styleClass="desktop-area">
-                              <Region fx:id="dropAnimationRegion" layoutX="32.0" layoutY="30.0" mouseTransparent="true" prefHeight="200.0" prefWidth="200.0" styleClass="search-drop-region" />
+                              <Region fx:id="desktopDropRegion" layoutX="24.0" layoutY="24.0" mouseTransparent="true" styleClass="desktop-drop-region" />
                            </AnchorPane>
                         </ScrollPane>
                      </center>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -2864,20 +2864,21 @@ Timeline Year line segment (will overlay change circles)
     -fx-min-width: 212px;
 }
 
-.search-drop-region {
-    -height: 840px;
+.desktop-drop-region {
+    -height: 940px;
     -width: 672px;
-    -fx-min-height: -height;
-    -fx-pref-height: -height;
     -fx-min-width: -width;
+    -fx-min-height: -height;
     -fx-pref-width: -width;
-    -fx-border-radius: 8;
-    -fx-background-radius: 8;
-    -fx-stroke: -Primary-04;
+    -fx-pref-height: -height;
     -fx-border-color: -Primary-04;
+    -fx-border-radius: 8;
     -fx-border-width: 4;
-    -fx-border-style: dashed;
-    -fx-background-color: rgba(255, 255, 255, 0.50);    
+    -fx-border-style: segments(12, 16) phase -8 line-join round line-cap round;
+    -fx-background-radius: 8;
+    -fx-background-insets: 0, 4;
+    /* The second color is obtained as a result of blending the current workspace background color and the white color with 50% opacity */
+    -fx-background-color: white, #e5e9f1;
 }
 
 /* Styles title text inside the content of TitlePane. eg: DESCRIPTION , Fully Qualified Name.*/


### PR DESCRIPTION
…ea (#78)

* Make concept window default size same as drop zone area

* Drop region size and styling meets current Figma specs

* Fix return type for concept folder name when launching a new concept window

* Fix drag and drop event handler for concept navigation and search panel

* Rename `id` and `styleclass` for the desktop drop region